### PR TITLE
Add isEqual comparison to MOMethod

### DIFF
--- a/Mocha/Objects/MOMethod.m
+++ b/Mocha/Objects/MOMethod.m
@@ -29,6 +29,20 @@
     return method;
 }
 
+- (BOOL)isEqual:(id)object
+{
+  if ([object isKindOfClass: [MOMethod class]] == NO)
+    return NO;
+  
+  MOMethod *objectMethod = (MOMethod *)object;
+  return ([objectMethod->_target isEqual: self->_target] && objectMethod->_selector == self->_selector && objectMethod->_block == self->_block);
+}
+
+- (NSUInteger)hash
+{
+  return [self.target hash] + [NSStringFromSelector(self.selector) hash] + [self.block hash];
+}
+
 - (NSString *)description {
     return [NSString stringWithFormat:@"<%@: %p : target=%@, selector=%@>", [self class], self, [self target], NSStringFromSelector([self selector])];
 }


### PR DESCRIPTION
This keeps Mocha from creating a new MOMethod each time it encounters the same target sending the same action (This happens a lot in for loops). Note this helps reduce the incidence of this issue (https://github.com/ccgus/CocoaScript/issues/8) but does not completely eliminate it.