### PR TITLE
Ensure NSMapTable is setup properly

### DIFF
--- a/Mocha/Runtime/MORuntime.m
+++ b/Mocha/Runtime/MORuntime.m
@@ -116,7 +116,10 @@ NSString * MOPropertyNameToSetterName(NSString *propertyName);
         self.options = options;
         
         _ctx = JSGlobalContextCreate(MochaClass);
-        _objectsToBoxes = [NSMapTable weakToStrongObjectsMapTable];
+        _objectsToBoxes = [NSMapTable
+                           mapTableWithKeyOptions:NSPointerFunctionsWeakMemory | NSPointerFunctionsObjectPointerPersonality
+                           valueOptions:NSPointerFunctionsStrongMemory | NSPointerFunctionsObjectPersonality];
+//        _objectsToBoxes = [NSMapTable weakToStrongObjectsMapTable];
         
         NSArray *libraryPaths = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSAllDomainsMask, YES);
         NSMutableArray *frameworkSearchPaths = [NSMutableArray arrayWithCapacity:[libraryPaths count]];


### PR DESCRIPTION
To ensure isEqual is not used when comparing object pointers the map table needs to be setup differently. This ensures mutable Objective-C types are compared by their true memory pointer rather than their contents.

This fixes #21 