### PR TITLE
Ensure objects to boxes NSMapTable is setup properly

### DIFF
--- a/Mocha/Runtime/MORuntime.m
+++ b/Mocha/Runtime/MORuntime.m
@@ -116,7 +116,9 @@ NSString * MOPropertyNameToSetterName(NSString *propertyName);
         self.options = options;
         
         _ctx = JSGlobalContextCreate(MochaClass);
-        _objectsToBoxes = [NSMapTable weakToStrongObjectsMapTable];
+        _objectsToBoxes = [NSMapTable
+                           mapTableWithKeyOptions:NSMapTableWeakMemory | NSMapTableObjectPointerPersonality
+                           valueOptions:NSMapTableStrongMemory | NSMapTableObjectPointerPersonality];
         
         NSArray *libraryPaths = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSAllDomainsMask, YES);
         NSMutableArray *frameworkSearchPaths = [NSMutableArray arrayWithCapacity:[libraryPaths count]];


### PR DESCRIPTION
The current setup is invalid as it's using the Objective-C method isEqual: and hash: rather than strict pointer comparison which is what we want.

This fixes issue #22  and also #21 as far as I can tell.