### PR TITLE
Bottleneck exceptions

### DIFF
--- a/Mocha/Invocation/MOFunctionArgument.m
+++ b/Mocha/Invocation/MOFunctionArgument.m
@@ -185,7 +185,7 @@ NSString * MOJSValueToString(JSContextRef ctx, JSValueRef value, JSValueRef *exc
     }
     else {
         if (![MOFunctionArgument getSize:NULL ofTypeEncoding:_baseTypeEncoding]) {
-            @throw [NSException exceptionWithName:MORuntimeException reason:[NSString stringWithFormat:@"Invalid type encoding: %c", _baseTypeEncoding] userInfo:nil];
+            @throw MOThrowableRuntimeException([NSString stringWithFormat:@"Invalid type encoding: %c", _baseTypeEncoding]);
         };
         
         _structureType.size = 0;
@@ -239,7 +239,7 @@ NSString * MOJSValueToString(JSContextRef ctx, JSValueRef value, JSValueRef *exc
 
 - (void)allocateStorage {
     if (!_typeEncoding) {
-        @throw [NSException exceptionWithName:MORuntimeException reason:[NSString stringWithFormat:@"No type encoding set in %@", self] userInfo:nil];
+        @throw MOThrowableRuntimeException([NSString stringWithFormat:@"No type encoding set in %@", self]);
     }
     
     BOOL success = NO;
@@ -270,7 +270,7 @@ NSString * MOJSValueToString(JSContextRef ctx, JSValueRef value, JSValueRef *exc
         _storage = malloc(size);
     }
     else {
-        @throw [NSException exceptionWithName:MORuntimeException reason:[NSString stringWithFormat:@"Unable to allocate storage for argument type %c", _baseTypeEncoding] userInfo:nil];
+        @throw MOThrowableRuntimeException([NSString stringWithFormat:@"Unable to allocate storage for argument type %c", _baseTypeEncoding]);
     }
 }
 
@@ -288,7 +288,7 @@ NSString * MOJSValueToString(JSContextRef ctx, JSValueRef value, JSValueRef *exc
         *ptr = (void *)address;
     }
     else {
-        @throw [NSException exceptionWithName:MORuntimeException reason:[NSString stringWithFormat:@"Unable to align pointer for argument type %c", encoding] userInfo:nil];
+        @throw MOThrowableRuntimeException([NSString stringWithFormat:@"Unable to align pointer for argument type %c", encoding]);
     }
 }
 
@@ -302,7 +302,7 @@ NSString * MOJSValueToString(JSContextRef ctx, JSValueRef value, JSValueRef *exc
         *ptr = (void*)address;
     }
     else {
-        @throw [NSException exceptionWithName:MORuntimeException reason:[NSString stringWithFormat:@"Unable to advance pointer for argument type %c", encoding] userInfo:nil];
+        @throw MOThrowableRuntimeException([NSString stringWithFormat:@"Unable to advance pointer for argument type %c", encoding]);
     }
 }
 
@@ -328,12 +328,12 @@ NSString * MOJSValueToString(JSContextRef ctx, JSValueRef value, JSValueRef *exc
             encoding = [_typeEncoding substringFromIndex:1];
         }
         else {
-            @throw [NSException exceptionWithName:MORuntimeException reason:[NSString stringWithFormat:@"Unable to dereference non-pointer value: %@", self] userInfo:nil];
+            @throw MOThrowableRuntimeException([NSString stringWithFormat:@"Unable to dereference non-pointer value: %@", self]);
         }
     }
     
     if (![MOFunctionArgument toJSValue:&value inContext:ctx typeEncoding:typeEncoding fullTypeEncoding:encoding storage:p]) {
-        @throw [NSException exceptionWithName:MORuntimeException reason:[NSString stringWithFormat:@"Getting value as JSValue failed: %@", self] userInfo:nil];
+        @throw MOThrowableRuntimeException([NSString stringWithFormat:@"Getting value as JSValue failed: %@", self]);
     }
     
     return value;
@@ -357,12 +357,12 @@ NSString * MOJSValueToString(JSContextRef ctx, JSValueRef value, JSValueRef *exc
                 encoding = [_typeEncoding substringFromIndex:1];
             }
             else {
-                @throw [NSException exceptionWithName:MORuntimeException reason:[NSString stringWithFormat:@"Unable to dereference non-pointer value: %@", self] userInfo:nil];
+                @throw MOThrowableRuntimeException([NSString stringWithFormat:@"Unable to dereference non-pointer value: %@", self]);
             }
         }
         
         if (![MOFunctionArgument fromJSValue:value inContext:ctx typeEncoding:typeEncoding fullTypeEncoding:encoding storage:p]) {
-            @throw [NSException exceptionWithName:MORuntimeException reason:[NSString stringWithFormat:@"Setting value from JSValue failed: %@, %@", self, MOJSValueToString(ctx, value, NULL)] userInfo:nil];
+            @throw MOThrowableRuntimeException([NSString stringWithFormat:@"Setting value from JSValue failed: %@, %@", self, MOJSValueToString(ctx, value, NULL)]);
         }
     }
     else {
@@ -565,7 +565,7 @@ typedef struct { char a; BOOL b; } struct_C_BOOL;
     id symbol = [[MOBridgeSupportController sharedController] symbolWithName:structureName type:[MOBridgeSupportStruct class]];
     
     if (symbol == nil) {
-        @throw [NSException exceptionWithName:MORuntimeException reason:[NSString stringWithFormat:@"No structure encoding found for %@", structureName] userInfo:nil];
+        @throw MOThrowableRuntimeException([NSString stringWithFormat:@"No structure encoding found for %@", structureName]);
         return nil;
     }
     

--- a/Mocha/Invocation/MOFunctionInvocation.m
+++ b/Mocha/Invocation/MOFunctionInvocation.m
@@ -232,7 +232,7 @@ JSValueRef MOFunctionInvoke(id function, JSContextRef ctx, size_t argumentCount,
         }
     }
     else {
-        @throw [NSException exceptionWithName:MORuntimeException reason:[NSString stringWithFormat:@"Invalid object for function invocation: %@", function] userInfo:nil];
+        @throw MOThrowableRuntimeException([NSString stringWithFormat:@"Invalid object for function invocation: %@", function]);
     }
     
     

--- a/Mocha/Invocation/MOFunctionInvocation.m
+++ b/Mocha/Invocation/MOFunctionInvocation.m
@@ -80,8 +80,7 @@ JSValueRef MOFunctionInvoke(id function, JSContextRef ctx, size_t argumentCount,
         if ((selector == @selector(release) || selector == @selector(autorelease))
                  && runtime.options & MORuntimeOptionAutomaticReferenceCounting) {
             // ARC-mode disallows explicit release of objects
-            NSException *e = [NSException exceptionWithName:MORuntimeException reason:[NSString stringWithFormat:@"Automatic reference counting disallows explicit calls to -%@.", NSStringFromSelector(selector)] userInfo:nil];
-            *exception = [runtime JSValueForObject:e inContext:ctx];
+            MORaiseRuntimeException(exception, [NSString stringWithFormat:@"Automatic reference counting disallows explicit calls to -%@.", NSStringFromSelector(selector)], runtime, ctx);
             return NULL;
         }
         
@@ -104,10 +103,7 @@ JSValueRef MOFunctionInvoke(id function, JSContextRef ctx, size_t argumentCount,
         variadic = [function isVariadic];
         
         if (method == NULL) {
-            NSException *e = [NSException exceptionWithName:MORuntimeException reason:[NSString stringWithFormat:@"Unable to locate method %@ of class %@", NSStringFromSelector(selector), klass] userInfo:nil];
-            if (exception != NULL) {
-                *exception = [runtime JSValueForObject:e inContext:ctx];
-            }
+            MORaiseRuntimeException(exception, [NSString stringWithFormat:@"Unable to locate method %@ of class %@", NSStringFromSelector(selector), klass], runtime, ctx);
             return NULL;
         }
         
@@ -115,10 +111,7 @@ JSValueRef MOFunctionInvoke(id function, JSContextRef ctx, size_t argumentCount,
         argumentEncodings = [[MOFunctionArgument argumentsFromTypeSignature:[NSString stringWithCString:encoding encoding:NSUTF8StringEncoding]] mutableCopy];
         
         if (argumentEncodings == nil) {
-            NSException *e = [NSException exceptionWithName:MORuntimeException reason:[NSString stringWithFormat:@"Unable to parse method encoding for method %@ of class %@", NSStringFromSelector(selector), klass] userInfo:nil];
-            if (exception != NULL) {
-                *exception = [runtime JSValueForObject:e inContext:ctx];
-            }
+            MORaiseRuntimeException(exception, [NSString stringWithFormat:@"Unable to parse method encoding for method %@ of class %@", NSStringFromSelector(selector), klass], runtime, ctx);
             return NULL;
         }
         
@@ -139,10 +132,7 @@ JSValueRef MOFunctionInvoke(id function, JSContextRef ctx, size_t argumentCount,
             || (!variadic && (callAddressArgumentCount != argumentCount)))
         {
             NSString *reason = [NSString stringWithFormat:@"Objective-C method %@ requires %lu %@, but JavaScript passed %zd %@", NSStringFromSelector(selector), (unsigned long)callAddressArgumentCount, (callAddressArgumentCount == 1 ? @"argument" : @"arguments"), argumentCount, (argumentCount == 1 ? @"argument" : @"arguments")];
-            NSException *e = [NSException exceptionWithName:MORuntimeException reason:reason userInfo:nil];
-            if (exception != NULL) {
-                *exception = [runtime JSValueForObject:e inContext:ctx];
-            }
+            MORaiseRuntimeException(exception, reason, runtime, ctx);
             return NULL;
         }
     }
@@ -159,10 +149,7 @@ JSValueRef MOFunctionInvoke(id function, JSContextRef ctx, size_t argumentCount,
         argumentEncodings = [[MOFunctionArgument argumentsFromTypeSignature:[NSString stringWithCString:typeEncoding encoding:NSUTF8StringEncoding]] mutableCopy];
         
         if (argumentEncodings == nil) {
-            NSException *e = [NSException exceptionWithName:MORuntimeException reason:[NSString stringWithFormat:@"Unable to parse method encoding for method %@ of class %@", NSStringFromSelector(selector), [target class]] userInfo:nil];
-            if (exception != NULL) {
-                *exception = [runtime JSValueForObject:e inContext:ctx];
-            }
+            MORaiseRuntimeException(exception, [NSString stringWithFormat:@"Unable to parse method encoding for method %@ of class %@", NSStringFromSelector(selector), [target class]], runtime, ctx);
             return NULL;
         }
         
@@ -170,10 +157,7 @@ JSValueRef MOFunctionInvoke(id function, JSContextRef ctx, size_t argumentCount,
         
         if (callAddressArgumentCount != argumentCount) {
             NSString *reason = [NSString stringWithFormat:@"Block requires %lu %@, but JavaScript passed %zd %@", (unsigned long)callAddressArgumentCount, (callAddressArgumentCount == 1 ? @"argument" : @"arguments"), argumentCount, (argumentCount == 1 ? @"argument" : @"arguments")];
-            NSException *e = [NSException exceptionWithName:MORuntimeException reason:reason userInfo:nil];
-            if (exception != NULL) {
-                *exception = [runtime JSValueForObject:e inContext:ctx];
-            }
+            MORaiseRuntimeException(exception, reason, runtime, ctx);
             return NULL;
         }
     }
@@ -186,10 +170,7 @@ JSValueRef MOFunctionInvoke(id function, JSContextRef ctx, size_t argumentCount,
         
         // If the function cannot be found, raise an exception (instead of crashing)
         if (callAddress == NULL) {
-            if (exception != NULL) {
-                NSException *e = [NSException exceptionWithName:MORuntimeException reason:[NSString stringWithFormat:@"Unable to find function with name: %@", functionName] userInfo:nil];
-                *exception = [runtime JSValueForObject:e inContext:ctx];
-            }
+            MORaiseRuntimeException(exception, [NSString stringWithFormat:@"Unable to find function with name: %@", functionName], runtime, ctx);
             return NULL;
         }
         
@@ -246,10 +227,7 @@ JSValueRef MOFunctionInvoke(id function, JSContextRef ctx, size_t argumentCount,
             || (!variadic && (callAddressArgumentCount != argumentCount)))
         {
             NSString *reason = [NSString stringWithFormat:@"C function %@ requires %lu %@, but JavaScript passed %zd %@", functionName, (unsigned long)callAddressArgumentCount, (callAddressArgumentCount == 1 ? @"argument" : @"arguments"), argumentCount, (argumentCount == 1 ? @"argument" : @"arguments")];
-            NSException *e = [NSException exceptionWithName:MORuntimeException reason:reason userInfo:nil];
-            if (exception != NULL) {
-                *exception = [runtime JSValueForObject:e inContext:ctx];
-            }
+            MORaiseRuntimeException(exception, reason, runtime, ctx);
             return NULL;
         }
     }
@@ -371,10 +349,7 @@ JSValueRef MOFunctionInvoke(id function, JSContextRef ctx, size_t argumentCount,
     
     // Throw an exception if the prep call failed
     if (prep_status != FFI_OK) {
-        NSException *e = [NSException exceptionWithName:MORuntimeException reason:@"ffi_prep_cif failed" userInfo:nil];
-        if (exception != NULL) {
-            *exception = [runtime JSValueForObject:e inContext:ctx];
-        }
+        MORaiseRuntimeException(exception, @"ffi_prep_cif failed", runtime, ctx);
         return NULL;
     }
     
@@ -438,10 +413,7 @@ JSValueRef MOSelectorInvoke(id target, SEL selector, JSContextRef ctx, size_t ar
     NSUInteger methodArgumentCount = [methodSignature numberOfArguments] - 2;
     if (methodArgumentCount != argumentCount) {
         NSString *reason = [NSString stringWithFormat:@"ObjC method %@ requires %lu %@, but JavaScript passed %zd %@", NSStringFromSelector(selector), (unsigned long)methodArgumentCount, (methodArgumentCount == 1 ? @"argument" : @"arguments"), argumentCount, (argumentCount == 1 ? @"argument" : @"arguments")];
-        NSException *e = [NSException exceptionWithName:MORuntimeException reason:reason userInfo:nil];
-        if (exception != NULL) {
-            *exception = [runtime JSValueForObject:e inContext:ctx];
-        }
+        MORaiseRuntimeException(exception, reason, runtime, ctx);
         return NULL;
     }
     

--- a/Mocha/Objects/MOBlock.m
+++ b/Mocha/Objects/MOBlock.m
@@ -41,7 +41,7 @@ SEL __proxySelector = NULL;
     if ([arguments count] != 2
         || ![arguments[0] isKindOfClass:[NSString class]]
         || ![arguments[1] isKindOfClass:[MOJavaScriptObject class]]) {
-        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"Block objects require two arguments: a type encoding and a function object" userInfo:nil];
+        @throw MOThrowableExceptionNamed(NSInvalidArgumentException, @"Block objects require two arguments: a type encoding and a function object");
     }
     return [[self alloc] initWithJavaScriptObject:arguments[1] typeEncoding:arguments[0]];
 }

--- a/Mocha/Objects/MOStruct.m
+++ b/Mocha/Objects/MOStruct.m
@@ -8,6 +8,7 @@
 
 #import "MOStruct.h"
 #import "MORuntime.h"
+#import "MORuntime_Private.h"
 
 
 @implementation MOStruct {
@@ -69,14 +70,14 @@
 
 - (id)objectForMemberName:(NSString *)name {
     if (![_memberNames containsObject:name]) {
-        @throw [NSException exceptionWithName:MORuntimeException reason:[NSString stringWithFormat:@"Struct %@ has no member named %@", self.name, name] userInfo:nil];
+        @throw MOThrowableRuntimeException([NSString stringWithFormat:@"Struct %@ has no member named %@", self.name, name]);
     }
     return [_memberValues objectForKey:name];
 }
 
 - (void)setObject:(id)obj forMemberName:(NSString *)name {
     if (![_memberNames containsObject:name]) {
-        @throw [NSException exceptionWithName:MORuntimeException reason:[NSString stringWithFormat:@"Struct %@ has no member named %@", self.name, name] userInfo:nil];
+        @throw MOThrowableRuntimeException([NSString stringWithFormat:@"Struct %@ has no member named %@", self.name, name]);
     }
     [_memberValues setObject:obj forKey:name];
 }

--- a/Mocha/Objects/MOWeak.m
+++ b/Mocha/Objects/MOWeak.m
@@ -7,6 +7,7 @@
 //
 
 #import "MOWeak.h"
+#import "MORuntime_Private.h"
 
 
 @implementation MOWeak {
@@ -15,7 +16,7 @@
 
 + (id)constructWithArguments:(NSArray *)arguments {
     if ([arguments count] == 0) {
-        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"Weak references require one argument" userInfo:nil];
+        @throw MOThrowableExceptionNamed(NSInvalidArgumentException, @"Weak references require one argument");
     }
     return [[self alloc] initWithValue:[arguments objectAtIndex:0]];
 }

--- a/Mocha/Runtime/MORuntime.m
+++ b/Mocha/Runtime/MORuntime.m
@@ -1262,8 +1262,7 @@ static JSValueRef MOObject_callAsFunction(JSContextRef ctx, JSObjectRef function
         return MOFunctionInvoke(function, ctx, argumentCount, arguments, exception);
     }
     else {
-        NSException *e = [NSException exceptionWithName:NSInvalidArgumentException reason:@"Object cannot be called as a function" userInfo:nil];
-        *exception = [runtime JSValueForObject:e inContext:ctx];
+        MORaiseRuntimeExceptionNamed(NSInvalidArgumentException, exception, [NSString stringWithFormat:@"Object %@ cannot be called as a function", function], runtime, ctx);
         return NULL;
     }
 }

--- a/Mocha/Runtime/MORuntime.m
+++ b/Mocha/Runtime/MORuntime.m
@@ -367,7 +367,7 @@ NSString * MOPropertyNameToSetterName(NSString *propertyName);
     }
     
     if (JSValueGetType(ctx, exception) != kJSTypeObject) {
-        NSException *mochaException = [NSException exceptionWithName:MOJavaScriptException reason:error userInfo:nil];
+        NSException *mochaException = MOThrowableExceptionNamed(MOJavaScriptException, error);
         return mochaException;
     }
     else {
@@ -392,7 +392,7 @@ NSString * MOPropertyNameToSetterName(NSString *propertyName);
         
         JSPropertyNameArrayRelease(jsNames);
         
-        NSException *mochaException = [NSException exceptionWithName:MOJavaScriptException reason:error userInfo:userInfo];
+        NSException *mochaException = MOThrowableExceptionNamedWithInfo(MOJavaScriptException, error, userInfo);
         return mochaException;
     }
 }
@@ -413,13 +413,30 @@ NSString * MOPropertyNameToSetterName(NSString *propertyName);
 }
 
 void MORaiseRuntimeException(JSValueRef *exception, NSString* reason, MORuntime* runtime, JSContextRef ctx) {
-    NSLog(@"raising exception for reason %@", reason);
-    NSException *e = [NSException exceptionWithName:MORuntimeException reason:reason userInfo:nil];
+    MORaiseRuntimeExceptionNamed(MORuntimeException, exception, reason, runtime, ctx);
+}
+
+void MORaiseRuntimeExceptionNamed(NSString* name, JSValueRef *exception, NSString* reason, MORuntime* runtime, JSContextRef ctx) {
+    NSLog(@"raising exception %@ for reason %@", name, reason);
+    NSException *e = MOThrowableExceptionNamed(name, reason);
     if (exception != NULL) {
         *exception = [runtime JSValueForObject:e inContext:ctx];
     }
-    
 }
+
+NSException* MOThrowableRuntimeException(NSString* reason) {
+    return MOThrowableExceptionNamedWithInfo(MORuntimeException, reason, nil);
+}
+
+NSException* MOThrowableExceptionNamed(NSString* name, NSString* reason) {
+    return MOThrowableExceptionNamedWithInfo(name, reason, nil);
+}
+
+NSException* MOThrowableExceptionNamedWithInfo(NSString* name, NSString* reason, NSDictionary* info) {
+    NSLog(@"throwing exception for reason %@", reason);
+    return [NSException exceptionWithName:name reason:reason userInfo:info];
+}
+
 
 #pragma mark -
 #pragma mark BridgeSupport Metadata

--- a/Mocha/Runtime/MORuntime_Private.h
+++ b/Mocha/Runtime/MORuntime_Private.h
@@ -35,3 +35,6 @@
 - (void)installBuiltins;
 
 @end
+
+extern void MORaiseRuntimeException(JSValueRef *exception, NSString* reason, MORuntime* runtime, JSContextRef ctx);
+

--- a/Mocha/Runtime/MORuntime_Private.h
+++ b/Mocha/Runtime/MORuntime_Private.h
@@ -37,4 +37,7 @@
 @end
 
 extern void MORaiseRuntimeException(JSValueRef *exception, NSString* reason, MORuntime* runtime, JSContextRef ctx);
+extern void MORaiseRuntimeExceptionNamed(NSString* name, JSValueRef *exception, NSString* reason, MORuntime* runtime, JSContextRef ctx);
+extern NSException* MOThrowableRuntimeException(NSString* reason);
+extern NSException* MOThrowableExceptionNamed(NSString* name, NSString* reason);
 


### PR DESCRIPTION
Whilst I was debugging the crash, a while back, I put all the exception throwing through a couple of functions, to make it easier to breakpoint / log them.

It turned out to be a red herring, but here's the work, just in case you want to incorporate it anyway (it's arguably a little bit of a reduction of duplication).
