### PR TITLE
Fix so Javascript can call CoreData object properties

### DIFF
--- a/Mocha.xcodeproj/project.pbxproj
+++ b/Mocha.xcodeproj/project.pbxproj
@@ -73,6 +73,8 @@
 		02CBE14118593D0900B8D16D /* MOBlock.m in Sources */ = {isa = PBXBuildFile; fileRef = 02CBE13E18593D0900B8D16D /* MOBlock.m */; };
 		02DCA800185677A60047EF92 /* MOFunctionInvocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 02DCA7FE185677A60047EF92 /* MOFunctionInvocation.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		02DCA802185677A60047EF92 /* MOFunctionInvocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 02DCA7FF185677A60047EF92 /* MOFunctionInvocation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		9F54B8DA1AEB431400AB4378 /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 9F54B8D81AEB431400AB4378 /* Model.xcdatamodeld */; };
+		9F54B8DC1AEB432B00AB4378 /* MochaPropertyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F54B8DB1AEB432B00AB4378 /* MochaPropertyTests.m */; };
 		EA037E701560B4C100D3E7C8 /* MOFunctionArgument.h in Headers */ = {isa = PBXBuildFile; fileRef = EA037E6E1560B4C100D3E7C8 /* MOFunctionArgument.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EA1A1232156160F200A1F1A4 /* libffi.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = EA1A1231156160F200A1F1A4 /* libffi.dylib */; };
 		EAA34F9E156304A800B62244 /* MOUndefined.h in Headers */ = {isa = PBXBuildFile; fileRef = EAA34F9C156304A800B62244 /* MOUndefined.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -191,7 +193,9 @@
 		02CBE13D18593D0900B8D16D /* MOBlock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOBlock.h; sourceTree = "<group>"; };
 		02CBE13E18593D0900B8D16D /* MOBlock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MOBlock.m; sourceTree = "<group>"; };
 		02DCA7FE185677A60047EF92 /* MOFunctionInvocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOFunctionInvocation.h; sourceTree = "<group>"; };
-		02DCA7FF185677A60047EF92 /* MOFunctionInvocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MOFunctionInvocation.m; sourceTree = "<group>"; };
+		02DCA7FF185677A60047EF92 /* MOFunctionInvocation.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = MOFunctionInvocation.m; sourceTree = "<group>"; };
+		9F54B8D91AEB431400AB4378 /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
+		9F54B8DB1AEB432B00AB4378 /* MochaPropertyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MochaPropertyTests.m; sourceTree = "<group>"; };
 		EA037E6E1560B4C100D3E7C8 /* MOFunctionArgument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MOFunctionArgument.h; sourceTree = "<group>"; };
 		EA037E6F1560B4C100D3E7C8 /* MOFunctionArgument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MOFunctionArgument.m; sourceTree = "<group>"; };
 		EA1A1231156160F200A1F1A4 /* libffi.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libffi.dylib; path = usr/lib/libffi.dylib; sourceTree = SDKROOT; };
@@ -293,6 +297,8 @@
 		02679ED71A2D381E0027DB63 /* MochaTests */ = {
 			isa = PBXGroup;
 			children = (
+				9F54B8DB1AEB432B00AB4378 /* MochaPropertyTests.m */,
+				9F54B8D81AEB431400AB4378 /* Model.xcdatamodeld */,
 				02679EDA1A2D381E0027DB63 /* MochaTests.m */,
 				02770DC31A2D395D0030D87F /* Tests */,
 				02679ED81A2D381E0027DB63 /* Supporting Files */,
@@ -656,6 +662,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				02679EDB1A2D381E0027DB63 /* MochaTests.m in Sources */,
+				9F54B8DC1AEB432B00AB4378 /* MochaPropertyTests.m in Sources */,
+				9F54B8DA1AEB431400AB4378 /* Model.xcdatamodeld in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1035,6 +1043,19 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		9F54B8D81AEB431400AB4378 /* Model.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				9F54B8D91AEB431400AB4378 /* Model.xcdatamodel */,
+			);
+			currentVersion = 9F54B8D91AEB431400AB4378 /* Model.xcdatamodel */;
+			path = Model.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = EAA45DF9155CE44B00F93E40 /* Project object */;
 }

--- a/Mocha/Invocation/MOFunctionInvocation.m
+++ b/Mocha/Invocation/MOFunctionInvocation.m
@@ -27,6 +27,19 @@
 #import <dlfcn.h>
 #import <ffi/ffi.h>
 
+@interface NSMethodSignature (Mocha)
+- (NSString *)typeEncoding;
+@end
+@implementation NSMethodSignature (Mocha)
+- (NSString *)typeEncoding {
+  NSString *encoding = [NSString stringWithFormat: @"%s", [self methodReturnType]];
+  for (NSUInteger i = 0;i < [self numberOfArguments];++i) {
+    const char *argType = [self getArgumentTypeAtIndex:i];
+    encoding = [encoding stringByAppendingFormat: @"%s", argType];
+  }
+  return encoding;
+}
+@end
 
 void * MOGetObjCCallAddressForArguments(NSArray *arguments);
 const char * MOBlockGetTypeEncoding(id blockObj);
@@ -91,6 +104,7 @@ JSValueRef MOFunctionInvoke(id function, JSContextRef ctx, size_t argumentCount,
         }
         
         Method method = NULL;
+        IMP method_imp = NULL;
         BOOL classMethod = (target == klass);
         
         // Determine the method type
@@ -99,11 +113,14 @@ JSValueRef MOFunctionInvoke(id function, JSContextRef ctx, size_t argumentCount,
         }
         else {
             method = class_getInstanceMethod(klass, selector);
+            /* For dynamic properties from CoreData, method will be NULL, but we can still get the method_imp and the methodSignature from the object */
+            method_imp = [target methodForSelector: selector];
+        
         }
         
         variadic = [function isVariadic];
         
-        if (method == NULL) {
+        if (method == NULL && method_imp == NULL) {
             NSException *e = [NSException exceptionWithName:MORuntimeException reason:[NSString stringWithFormat:@"Unable to locate method %@ of class %@", NSStringFromSelector(selector), klass] userInfo:nil];
             if (exception != NULL) {
                 *exception = [runtime JSValueForObject:e inContext:ctx];
@@ -111,7 +128,11 @@ JSValueRef MOFunctionInvoke(id function, JSContextRef ctx, size_t argumentCount,
             return NULL;
         }
         
-        const char *encoding = method_getTypeEncoding(method);
+        const char *encoding;
+        if (method)
+            encoding = method_getTypeEncoding(method);
+        else
+            encoding = [[[target methodSignatureForSelector: selector] typeEncoding] cStringUsingEncoding: NSASCIIStringEncoding];
         argumentEncodings = [[MOFunctionArgument argumentsFromTypeSignature:[NSString stringWithCString:encoding encoding:NSUTF8StringEncoding]] mutableCopy];
         
         if (argumentEncodings == nil) {

--- a/MochaTests/MochaPropertyTests.m
+++ b/MochaTests/MochaPropertyTests.m
@@ -1,0 +1,138 @@
+//
+//  MochaPropertyTests.m
+//  Mocha
+//
+//  Created by Adam Fedor on 4/24/15.
+//  Copyright (c) 2015 Sunflower Softworks. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+#import <XCTest/XCTest.h>
+#import <Mocha/Mocha.h>
+#import <objc/runtime.h>
+#import <CoreData/CoreData.h>
+
+@interface Product : NSManagedObject
+@property (nonatomic, retain) NSString * name;
+@end
+@implementation Product
+@dynamic name;
+
+@end
+
+@interface MochaTestDynamicProperty : NSObject
+@property NSString *testProperty;
+@end
+@implementation MochaTestDynamicProperty
+@dynamic testProperty;
+
+id dynamicMethodIMP(id self, SEL _cmd) {
+  return [self valueForUndefinedKey: NSStringFromSelector(_cmd)];
+}
+
++ (BOOL)resolveInstanceMethod:(SEL)aSEL
+{
+  if (aSEL == @selector(testProperty)) {
+    class_addMethod([self class], aSEL, (IMP) dynamicMethodIMP, "@@:");
+    return YES;
+  }
+  return [super resolveInstanceMethod:aSEL];
+}
+
+- (id)valueForUndefinedKey:(NSString *)key
+{
+  return @"testValue";
+}
+
+@end
+
+@interface MochaPropertyTests : XCTestCase
+@end
+
+@implementation MochaPropertyTests
+{
+  MORuntime *runtime;
+  NSURL *testModelURL;
+  NSManagedObjectContext *moContext;
+}
+
+- (void)setUp {
+  [super setUp];
+  testModelURL = [[NSBundle bundleForClass: [self class]] URLForResource:@"Model" withExtension:@"momd"];
+  runtime = [[MORuntime alloc] init];
+
+  NSError *error = nil;
+  NSPersistentStoreCoordinator *coordinator = nil;
+  NSManagedObjectModel *model = nil;
+  moContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
+  model = [[NSManagedObjectModel alloc] initWithContentsOfURL: testModelURL];
+  coordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel: model];
+  
+  [coordinator addPersistentStoreWithType: NSInMemoryStoreType
+                            configuration: nil
+                                      URL: [NSURL fileURLWithPath: @"/tmp/testmodel"]
+                                  options: 0
+                                    error: &error];
+  [moContext setPersistentStoreCoordinator: coordinator];
+}
+
+- (void)tearDown {
+  [super tearDown];
+}
+
+- (void)testCallDynamicProperty_ShouldReturnSimpleObject
+{
+  MochaTestDynamicProperty *dynamicObject = [[MochaTestDynamicProperty alloc] init];
+  
+  [runtime evaluateString: @"function getTestProperty(object) { return object.testProperty }"];
+  id callable = runtime.globalObject[@"getTestProperty"];
+  id result = [callable callWithArguments: @[dynamicObject]];
+  XCTAssertEqual(result, @"testValue", @"Property not correct");
+}
+
+#pragma mark Managed Object Properties
+- (void)testCallSubclassedManagedObjectProperty_ShouldReturnSimpleObject
+{
+  NSManagedObject *modelObject = [NSEntityDescription insertNewObjectForEntityForName: @"Product" inManagedObjectContext: moContext];
+  [modelObject setValue: @"testValue" forKey: @"name"];
+  
+  [runtime evaluateString: @"function getTestProperty(object) { return object.name }"];
+  id callable = runtime.globalObject[@"getTestProperty"];
+  id result = [callable callWithArguments: @[modelObject]];
+  
+  XCTAssertEqual(result, @"testValue", @"Property not correct");
+}
+
+- (void)testSetSubclassedManagedObjectProperty_ShouldReturnSimpleObject
+{
+  NSManagedObject *modelObject = [NSEntityDescription insertNewObjectForEntityForName: @"Product" inManagedObjectContext: moContext];  
+  [runtime evaluateString: @"function setTestProperty(object) { object.name = \"testValue\" }"];
+  id callable = runtime.globalObject[@"setTestProperty"];
+  [callable callWithArguments: @[modelObject]];
+  
+  XCTAssertTrue([[modelObject valueForKey: @"name"] isEqualToString: @"testValue"], @"Property not set");
+}
+
+- (void)testCallDynamicManagedObjectProperty_ShouldReturnSimpleObject
+{
+  NSManagedObject *modelObject = [NSEntityDescription insertNewObjectForEntityForName: @"ManagedItem" inManagedObjectContext: moContext];
+  [modelObject setValue: @"testValue" forKey: @"name"];
+  
+  [runtime evaluateString: @"function getTestProperty(object) { return object.name }"];
+  id callable = runtime.globalObject[@"getTestProperty"];
+  id result = [callable callWithArguments: @[modelObject]];
+  
+  XCTAssertEqual(result, @"testValue", @"Property not correct");
+}
+
+- (void)testSetDynamicManagedObjectProperty_ShouldReturnSimpleObject
+{
+  NSManagedObject *modelObject = [NSEntityDescription insertNewObjectForEntityForName: @"ManagedItem" inManagedObjectContext: moContext];
+  [runtime evaluateString: @"function setTestProperty(object) { object.name = \"testValue\" }"];
+  id callable = runtime.globalObject[@"setTestProperty"];
+  [callable callWithArguments: @[modelObject]];
+  
+  XCTAssertTrue([[modelObject valueForKey: @"name"] isEqualToString: @"testValue"], @"Property not set");
+}
+
+@end

--- a/MochaTests/MochaPropertyTests.m
+++ b/MochaTests/MochaPropertyTests.m
@@ -52,13 +52,12 @@ id dynamicMethodIMP(id self, SEL _cmd) {
 @implementation MochaPropertyTests
 {
   MORuntime *runtime;
-  NSURL *testModelURL;
   NSManagedObjectContext *moContext;
 }
 
 - (void)setUp {
   [super setUp];
-  testModelURL = [[NSBundle bundleForClass: [self class]] URLForResource:@"Model" withExtension:@"momd"];
+  NSURL *testModelURL = [[NSBundle bundleForClass: [self class]] URLForResource:@"Model" withExtension:@"momd"];
   runtime = [[MORuntime alloc] init];
 
   NSError *error = nil;
@@ -106,28 +105,6 @@ id dynamicMethodIMP(id self, SEL _cmd) {
 - (void)testSetSubclassedManagedObjectProperty_ShouldReturnSimpleObject
 {
   NSManagedObject *modelObject = [NSEntityDescription insertNewObjectForEntityForName: @"Product" inManagedObjectContext: moContext];  
-  [runtime evaluateString: @"function setTestProperty(object) { object.name = \"testValue\" }"];
-  id callable = runtime.globalObject[@"setTestProperty"];
-  [callable callWithArguments: @[modelObject]];
-  
-  XCTAssertTrue([[modelObject valueForKey: @"name"] isEqualToString: @"testValue"], @"Property not set");
-}
-
-- (void)testCallDynamicManagedObjectProperty_ShouldReturnSimpleObject
-{
-  NSManagedObject *modelObject = [NSEntityDescription insertNewObjectForEntityForName: @"ManagedItem" inManagedObjectContext: moContext];
-  [modelObject setValue: @"testValue" forKey: @"name"];
-  
-  [runtime evaluateString: @"function getTestProperty(object) { return object.name }"];
-  id callable = runtime.globalObject[@"getTestProperty"];
-  id result = [callable callWithArguments: @[modelObject]];
-  
-  XCTAssertEqual(result, @"testValue", @"Property not correct");
-}
-
-- (void)testSetDynamicManagedObjectProperty_ShouldReturnSimpleObject
-{
-  NSManagedObject *modelObject = [NSEntityDescription insertNewObjectForEntityForName: @"ManagedItem" inManagedObjectContext: moContext];
   [runtime evaluateString: @"function setTestProperty(object) { object.name = \"testValue\" }"];
   id callable = runtime.globalObject[@"setTestProperty"];
   [callable callWithArguments: @[modelObject]];

--- a/MochaTests/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/MochaTests/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="7549" systemVersion="14C1514" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+    <entity name="ManagedItem" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Product" representedClassName="Product" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="Product" positionX="-54" positionY="-9" width="128" height="60"/>
+        <element name="ManagedItem" positionX="-54" positionY="0" width="128" height="60"/>
+    </elements>
+</model>

--- a/b.patch
+++ b/b.patch
@@ -1,0 +1,61 @@
+diff --git a/Mocha/Invocation/MOFunctionInvocation.m b/Mocha/Invocation/MOFunctionInvocation.m
+index 18214c2..e98839a 100644
+--- a/Mocha/Invocation/MOFunctionInvocation.m
++++ b/Mocha/Invocation/MOFunctionInvocation.m
+@@ -27,6 +27,19 @@
+ #import <dlfcn.h>
+ #import <ffi/ffi.h>
+ 
++@interface NSMethodSignature (Mocha)
++- (NSString *)typeEncoding;
++@end
++@implementation NSMethodSignature (Mocha)
++- (NSString *)typeEncoding {
++  NSString *encoding = [NSString stringWithFormat: @"%s", [self methodReturnType]];
++  for (NSUInteger i = 0;i < [self numberOfArguments];++i) {
++    const char *argType = [self getArgumentTypeAtIndex:i];
++    encoding = [encoding stringByAppendingFormat: @"%s", argType];
++  }
++  return encoding;
++}
++@end
+ 
+ void * MOGetObjCCallAddressForArguments(NSArray *arguments);
+ const char * MOBlockGetTypeEncoding(id blockObj);
+@@ -91,6 +104,7 @@ JSValueRef MOFunctionInvoke(id function, JSContextRef ctx, size_t argumentCount,
+         }
+         
+         Method method = NULL;
++        IMP method_imp = NULL;
+         BOOL classMethod = (target == klass);
+         
+         // Determine the method type
+@@ -99,11 +113,14 @@ JSValueRef MOFunctionInvoke(id function, JSContextRef ctx, size_t argumentCount,
+         }
+         else {
+             method = class_getInstanceMethod(klass, selector);
++            /* For dynamic properties from CoreData, method will be NULL, but we can still get the method_imp and the methodSignature from the object */
++            method_imp = [target methodForSelector: selector];
++        
+         }
+         
+         variadic = [function isVariadic];
+         
+-        if (method == NULL) {
++        if (method == NULL && method_imp == NULL) {
+             NSException *e = [NSException exceptionWithName:MORuntimeException reason:[NSString stringWithFormat:@"Unable to locate method %@ of class %@", NSStringFromSelector(selector), klass] userInfo:nil];
+             if (exception != NULL) {
+                 *exception = [runtime JSValueForObject:e inContext:ctx];
+@@ -111,7 +128,11 @@ JSValueRef MOFunctionInvoke(id function, JSContextRef ctx, size_t argumentCount,
+             return NULL;
+         }
+         
+-        const char *encoding = method_getTypeEncoding(method);
++        const char *encoding;
++        if (method)
++            encoding = method_getTypeEncoding(method);
++        else
++            encoding = [[[target methodSignatureForSelector: selector] typeEncoding] cStringUsingEncoding: NSASCIIStringEncoding];
+         argumentEncodings = [[MOFunctionArgument argumentsFromTypeSignature:[NSString stringWithCString:encoding encoding:NSUTF8StringEncoding]] mutableCopy];
+         
+         if (argumentEncodings == nil) {


### PR DESCRIPTION
Properties of subclassed CoreData objects can't be called from Javascript currently.  CoreData uses internal private functions to implement the dynamic properties, and this does not seem to work with the runtime method introspection functions, but they do work with NSObject introspection methods.  In this patch I only use the NSObject methods if the runtime functions fail, but it seems like you could use the NSObject methods always.

Includes some Unit Tests that illustrate the problem.